### PR TITLE
fix: plugin-context/outdir problems, add missing values to plugin-context

### DIFF
--- a/apps/espack/README.md
+++ b/apps/espack/README.md
@@ -266,16 +266,16 @@ hook into with your plugin by providing the enabled lifecycles to the
 object as properties.
 - Espack currently lets you hook into the following lifecycles of the build process:
     - **beforeResourceCheck**: Executed by esbuild before checking for build resource 
-      accessibility. Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles
+      accessibility. Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildProfiles (for current build), the current build profile
     - **onResourceCheck**: Executed parallel to espack's own resource checking mechanisms.
       You can check for any required resources by your plugin, espack will wait for every plugin
-      to complete before proceeding onward. Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles
+      to complete before proceeding onward. Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildProfiles, the current build profile
     - **afterResourceCheck**: Executed after the resource check process has been done. You can do 
       any additional modifications you wish to make to the context before the scripts are processed in the next cycle.
-      Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles
+      Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildProfiles, the current build profile
     - **beforeBuild**: Executed right before the build process begins with esbuild. The input scripts and build 
       profiles have been processed by this point, into a digestible format by esbuild.
-      Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildReadyScripts
+      Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildProfiles, the current build profile, buildReadyScripts
         - buildReadyScripts structure:
         ```json5
         {
@@ -290,12 +290,12 @@ object as properties.
       resource heavy build operation here, which will be executed parallel to the esbuild build. The result of your 
       build operation will be passed into your plugin in the next lifecycle, so there is no need for you to save it's 
       result.
-      Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildReadyScripts
+      Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildProfiles (for current build), the current build profile, buildReadyScripts
     - **afterBuild**: This lifecycle is run after esbuild has finished, or in watch mode after every rebuild. The results
       of esbuild and plugin build (only esbuild result in watch mode) are passed onto the plugin. Espack will write the
       results of esbuild after this lifecycle to the disk, so you can modify the esbuild results if you want to, though
       this is generally not recommended! (such operations should be done through esbuild plugins!)
-      Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildReadyScripts, buildResults, 
+      Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildProfiles (for current build), the current build profile, buildReadyScripts, buildResults, 
       pluginBuildResult (if any, also generic)
         - **buildResults** structure:
         ```json5
@@ -356,11 +356,11 @@ object as properties.
       are passed onto the plugin.
     - **registerCustomWatcher**: This lifecycle lets you register your custom watcher functions. You need to return
     a cleanup function which frees up your resources if watch is cancelled.
-    Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildReadyScripts, buildResults,
+    Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildProfiles (for current build), the current build profile, buildReadyScripts, buildResults,
     pluginBuildResult
     - **onCleanup**: This lifecycle is executed along with the espack shutdown process. Free up any resources you want
     here.
-    Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildReadyScripts, buildResults,
+    Context available in this lifecycle: buildsDir, scripts, defaultBuildProfiles, buildProfiles (for current build), the current build profile, buildReadyScripts, buildResults,
     pluginBuildResult
 - When any lifecycle is provided on the plugin object as a property the plugin execution for that lifecycle
 will be automatically enabled. So if you don't want your plugin to run on certain lifecycles simply don't provide a method

--- a/apps/espack/src/build/build.constants.ts
+++ b/apps/espack/src/build/build.constants.ts
@@ -47,6 +47,7 @@ const defaultEntryAssetTransformations: IEntryAssetTransformations = {
     minifyIdentifiers: false,
     minifySyntax: false,
     minifyWhitespace: false,
+    outdir: '',
     resolveExtensions: ['.tsx', '.ts', '.jsx', '.js', '.css', '.json'],
     sourcesContent: false,
     target: ['chrome58', 'firefox57', 'safari11', 'edge60', 'node12.9.0'],

--- a/apps/espack/src/build/build.model.ts
+++ b/apps/espack/src/build/build.model.ts
@@ -36,7 +36,6 @@ type OmmitedEntryAssetTransformations =
     | 'metafile'
     | 'banner'
     | 'outbase'
-    | 'outdir'
     | 'nodePaths'
     | 'outExtension'
     | 'publicPath'

--- a/apps/espack/src/builder/builder.helpers.ts
+++ b/apps/espack/src/builder/builder.helpers.ts
@@ -9,6 +9,7 @@ export type Watcher = (buildId: string, error: BuildFailure | undefined, result:
 
 export const executeBuilds = async (
     scripts: IDeterministicEntryAsset[],
+    buildsDir: string,
     onWatch: Watcher | undefined
 ): Promise<IBuildResult[]> => {
     const commonBuilds: ICommonBuild[] = scripts.reduce<ICommonBuild[]>((acc, curr) => {
@@ -43,6 +44,7 @@ export const executeBuilds = async (
                 build,
                 buildResult: await esbuilder({
                     ...build.buildProfile,
+                    outdir: path.join(buildsDir, build.buildProfile.outdir),
                     entryPoints: build.builds.map(script => script.src),
                     watch: onWatch
                         ? {
@@ -60,17 +62,15 @@ export const executeBuilds = async (
 };
 
 interface ICreateBuildReadyScripts {
-    buildsDir: string;
     scripts: IEntryAsset[];
-    buildProfile: string | undefined;
-    defaultBuildProfiles: BuildProfiles | undefined;
-    buildProfiles: BuildProfiles | undefined;
+    buildProfile: string;
+    defaultBuildProfiles: BuildProfiles;
+    buildProfiles: BuildProfiles;
     watch: boolean;
     singleBuildMode: boolean;
 }
 
 export const createBuildReadyScripts = ({
-    buildsDir,
     scripts,
     buildProfile,
     defaultBuildProfiles,
@@ -82,7 +82,6 @@ export const createBuildReadyScripts = ({
         createBuildReadyScript({
             script,
             watch,
-            buildsDir,
             singleBuildMode,
             currentBuildIndex: index,
             buildProfile,

--- a/apps/espack/src/index.ts
+++ b/apps/espack/src/index.ts
@@ -1,4 +1,16 @@
+import {
+    IEspackPlugin as IEspackPluginType,
+    BuildLifecycles as BuildLifecyclesType,
+    IBasePluginContext as IBasePluginContextType,
+    IBuildReadyPluginContext as IBuildReadyPluginContextType,
+    IBuiltPluginContext as IBuiltPluginContextType
+} from './build/build.plugin';
+export type IEspackPlugin<T = unknown> = IEspackPluginType<T>;
+export type BuildLifecycles = BuildLifecyclesType;
+export type IBasePluginContext = IBasePluginContextType;
+export type IBuildReadyPluginContext = IBuildReadyPluginContextType;
+export type IBuiltPluginContext<T> = IBuiltPluginContextType<T>;
+
 export * from './build/build.model';
-export * from './build/build.plugin';
 export * from './utils/create-build-profiles';
 export * from './utils';

--- a/apps/espack/src/utils/get-plugins-for-lifecycle.ts
+++ b/apps/espack/src/utils/get-plugins-for-lifecycle.ts
@@ -1,7 +1,7 @@
-import { BuildLifecycles, DeterministicEspackPlugin, IEspackPlugin } from '../build/build.plugin';
+import { DeterministicEspackMarkedPlugin, IEspackMarkedPlugin, IPluginHooks } from '../build/build.plugin';
 
-export const getPluginsForLifecycle = <T extends BuildLifecycles>(
-    plugins: IEspackPlugin[],
+export const getPluginsForLifecycle = <T extends keyof IPluginHooks>(
+    plugins: readonly IEspackMarkedPlugin[],
     lifecycle: T
-): DeterministicEspackPlugin<T>[] =>
-    (plugins.filter(plugin => plugin[lifecycle]) as unknown) as DeterministicEspackPlugin<T>[];
+): DeterministicEspackMarkedPlugin<T>[] =>
+    (plugins.filter(plugin => plugin[lifecycle]) as unknown) as DeterministicEspackMarkedPlugin<T>[];

--- a/common/changes/@es-pack/copy-plugin/bugfix--11-contexts-are-not-being-properly-passed-to-plugins_2021-06-03-20-33.json
+++ b/common/changes/@es-pack/copy-plugin/bugfix--11-contexts-are-not-being-properly-passed-to-plugins_2021-06-03-20-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@es-pack/copy-plugin",
+      "comment": "Updated to reflect the fixed outdir changes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@es-pack/copy-plugin",
+  "email": "csizmadia98@gmail.com"
+}

--- a/common/changes/@es-pack/espack/bugfix--11-contexts-are-not-being-properly-passed-to-plugins_2021-06-03-20-33.json
+++ b/common/changes/@es-pack/espack/bugfix--11-contexts-are-not-being-properly-passed-to-plugins_2021-06-03-20-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@es-pack/espack",
+      "comment": "Changed outdir to not include the buildsDir, added buildProfiles, and current buildProfile to the BasePluginContext, fixed plugin contexts not being properly passed to the plugins issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@es-pack/espack",
+  "email": "csizmadia98@gmail.com"
+}

--- a/common/changes/@es-pack/html-plugin/bugfix--11-contexts-are-not-being-properly-passed-to-plugins_2021-06-03-20-33.json
+++ b/common/changes/@es-pack/html-plugin/bugfix--11-contexts-are-not-being-properly-passed-to-plugins_2021-06-03-20-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@es-pack/html-plugin",
+      "comment": "Updated to reflect the fixed outdir changes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@es-pack/html-plugin",
+  "email": "csizmadia98@gmail.com"
+}

--- a/plugins/copy-plugin/README.md
+++ b/plugins/copy-plugin/README.md
@@ -56,8 +56,9 @@ The plugin can be reused any number of times.
 
 - **basedir**: The root dir to copy assets from. Defaults to the current working directory of espack.
 - **assets**: Array of assets (string paths) to copy, relative to the basedir. This entry is required.
-- **outdir**: Directory to output the copied assets into relative to espack's baseDir. Defaults to 
-"assets".
+- **outdir**: Directory to output the copied assets into relative to espack's baseDir and the outdir of 
+the current build. Defaults to "assets". So when the current basedir is "dist", and the outdir is "public"
+the plugin will default to "dist/public/assets".
 
 ## Watch mode
 

--- a/plugins/copy-plugin/src/index.ts
+++ b/plugins/copy-plugin/src/index.ts
@@ -1,13 +1,6 @@
 import fs, { FSWatcher } from 'fs';
 import path from 'path';
-import {
-    checkAssetsExist,
-    IEspackPlugin,
-    IBasePluginContext,
-    IBuildReadyPluginContext,
-    IBuiltPluginContext,
-    ICleanup
-} from '@es-pack/espack';
+import { checkAssetsExist, IEspackPlugin, IBuildReadyPluginContext, IBuiltPluginContext, ICleanup } from '@es-pack/espack';
 import Joi from 'joi';
 import { copyPluginOptionsSchema } from './validation/validator';
 
@@ -53,12 +46,16 @@ export const espackCopyPluginFactory = (options: IEspackCopyPluginOptions): IEsp
         return path.join(deterministicOptions.basedir, asset);
     };
 
-    const onResourceCheck = (context: IBasePluginContext): Promise<void> => {
+    const onResourceCheck = (): Promise<void> => {
         return checkAssetsExist([...deterministicOptions.assets.map(mapBasedirToAsset)]);
     };
 
     const onBuild = async (context: IBuildReadyPluginContext): Promise<void> => {
-        const assetsDir: string = path.join(context.buildsDir, deterministicOptions.outdir);
+        const outdir: string =
+            context.buildProfiles[context.buildProfile]?.outdir ||
+            context.defaultBuildProfiles[context.buildProfile]?.outdir ||
+            '';
+        const assetsDir: string = path.join(context.buildsDir, outdir, deterministicOptions.outdir);
         if (!fs.existsSync(assetsDir)) {
             fs.mkdirSync(assetsDir);
         }

--- a/plugins/html-plugin/src/utils/inject-scripts.ts
+++ b/plugins/html-plugin/src/utils/inject-scripts.ts
@@ -56,7 +56,7 @@ const getInjectables = (
         const outputScripts: OutputFile[] = outputFiles.filter(file => file.path.endsWith(`.${FileExtensions.JAVASCRIPT}`));
         const outputStyles: OutputFile[] = outputFiles.filter(file => file.path.endsWith(`.${FileExtensions.CSS}`));
 
-        const relativeBuildPath: string = path.relative(baseDir, buildResult.build.buildProfile.outdir);
+        const relativeBuildPath: string = buildResult.build.buildProfile.outdir;
 
         const injectableScripts: string[] = getInjectableAssets(
             relativeBuildPath,


### PR DESCRIPTION
Plugin contexts were not passed correctly to the plugins.

Added buildProfiles and buildProfile to the base plugin context

Fixed outdir including the buildsDir
